### PR TITLE
Remove `clear` method - closes #2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
+sudo: false # use faster docker infrastructure
 language: node_js
 node_js:
-  - 0.8
-  - 0.10
-  - 0.11
+  - '0.8'
+  - '0.10'
+  - '0.11'
+  - '0.12'
+  - 'iojs'
 
 notifications:
   email:

--- a/is-implemented.js
+++ b/is-implemented.js
@@ -12,7 +12,6 @@ module.exports = function () {
 	}
 	if (typeof weakMap.set !== 'function') return false;
 	if (weakMap.set({}, 1) !== weakMap) return false;
-	if (typeof weakMap.clear !== 'function') return false;
 	if (typeof weakMap.delete !== 'function') return false;
 	if (typeof weakMap.has !== 'function') return false;
 	if (weakMap.get(x) !== 'one') return false;

--- a/polyfill.js
+++ b/polyfill.js
@@ -39,9 +39,6 @@ if (isNative) {
 }
 
 Object.defineProperties(WeakMapPoly.prototype, {
-	clear: d(function () {
-		defineProperty(this, '__weakMapData__', d('c', '$weakMap$' + randomUniq()));
-	}),
 	delete: d(function (key) {
 		if (hasOwnProperty.call(object(key), this.__weakMapData__)) {
 			delete key[this.__weakMapData__];

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -16,10 +16,6 @@ module.exports = function (T, a) {
 	a(map.get(x), undefined, "Get: after delete");
 	a(map.has(x), false, "Has: after delete");
 
-	a(map.has(y), true, "Has: pre clear");
-	map.clear();
-	a(map.has(y), false, "Has: after clear");
-
 	a.h1("Empty initialization");
 	map = new T();
 	map.set(x, 'bar');


### PR DESCRIPTION
I've been using this shim and my tests are failing on iojs due to it not having the `clear` method on WeakMaps.  This removes the clear method and its usage as a check for WeakMap implementation.