### PR TITLE
Switched to instance toString method

### DIFF
--- a/is-implemented.js
+++ b/is-implemented.js
@@ -3,13 +3,13 @@
 module.exports = function () {
 	var weakMap, x;
 	if (typeof WeakMap !== 'function') return false;
-	if (String(WeakMap.prototype) !== '[object WeakMap]') return false;
 	try {
 		// WebKit doesn't support arguments and crashes
 		weakMap = new WeakMap([[x = {}, 'one'], [{}, 'two'], [{}, 'three']]);
 	} catch (e) {
 		return false;
 	}
+	if (String(weakMap) !== '[object WeakMap]') return false;
 	if (typeof weakMap.set !== 'function') return false;
 	if (weakMap.set({}, 1) !== weakMap) return false;
 	if (typeof weakMap.delete !== 'function') return false;


### PR DESCRIPTION
I understand you rejected a similar pull request previously, but I believe this is more acceptable.

Chrome actually does report the correct string, but only on instances of WeakMap.

I'm really keen to see this changed because, in my use cases, the native WeakMap is about 5 times faster than the polyfill, which ends up being a difference between 30ms and 150ms of latency in a UI.